### PR TITLE
Run the osc source validator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
   gcc-c++ \
   libtool \
   libxslt \
+  obs-service-source_validator \
   ruby-devel \
   sgml-skel \
   yast2-devtools \

--- a/yast-travis-cpp
+++ b/yast-travis-cpp
@@ -12,6 +12,11 @@ set -e -x
 # /proc and /sys in the chroot).
 rake tarball > /dev/null 2>&1
 
+if [ -d package ]; then
+  # run the osc source validator to check the .spec and .changes locally
+  (cd package && /usr/lib/obs/service/source_validator)
+fi
+
 cp package/* /usr/src/packages/SOURCES/
 # Build the binary package, if it fails try to build the package with ignored
 # deps, maybe it can work anyway...


### PR DESCRIPTION
Run the osc source validator at Travis to check the `*.spec` and `*.changes` locally.

I found out that in [this PR](https://github.com/yast/yast-packager/pull/225) build succeeded at Travis but [failed in Jenkins](https://ci.opensuse.org/job/yast-packager-github-push/231//console). It turned out that the Jenkins failure was caused by a wrong changelog sequence (dates not in ascending order) which is not tested at Travis.

To make the Travis builds more close to the OBS builds we should run this additional check at Travis as well.
