### PR TITLE
Added the "sle12-sp3" image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ env:
   # define the build matrix to build all images in parallel
   - DOCKER_TAG=latest
   - DOCKER_TAG=sle12-sp2
+  - DOCKER_TAG=sle12-sp3
   - DOCKER_TAG=caasp-1_0

--- a/Dockerfile.sle12-sp3
+++ b/Dockerfile.sle12-sp3
@@ -1,0 +1,69 @@
+# SLE12-SP3 is officially not available at the Docker Hub
+# because of some licensing issues, use openSUSE-42.3 as a replacement.
+# It shares the same core packages and should be close enough to SLE12-SP3
+# for running the YaST tests.
+# FIXME: for now use the TW base, 42.3 (beta) has not been published yet,
+# after releasing 42.3 update this line to:
+# FROM opensuse:42.3
+FROM opensuse:tumbleweed
+
+# Set a higher priority for the yast_sle_12_sp3 repo to prefer the packages from
+# this repo even if they have a lower version than the original 42.3 packages.
+# FIXME: use the TW build target for now, later switch to:
+# RUN zypper ar -f -p 95 http://download.opensuse.org/repositories/YaST:/SLE-12:/SP3/SLE_12_SP3/ \
+RUN zypper ar -f -p 95 http://download.opensuse.org/repositories/YaST:/SLE-12:/SP3/openSUSE_Tumbleweed/ \
+  yast_sle12_sp3
+
+# we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
+# see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
+# https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache
+# why we need "zypper clean -a" at the end
+RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+  ruby && zypper clean -a
+
+RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
+  zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+  aspell-en \
+  fdupes \
+  git \
+  grep \
+  rpm-build \
+  update-desktop-files \
+  which \
+  screen \
+  "rubygem($RUBY_VERSION:fast_gettext)" \
+  "rubygem($RUBY_VERSION:gettext)" \
+  "rubygem($RUBY_VERSION:raspell)" \
+  "rubygem($RUBY_VERSION:rspec)" \
+  "rubygem($RUBY_VERSION:rubocop)" \
+  "rubygem($RUBY_VERSION:simplecov)" \
+  "rubygem($RUBY_VERSION:yard)" \
+  "rubygem($RUBY_VERSION:yast-rake)" \
+  autoconf \
+  automake \
+  bison \
+  boost-devel \
+  cmake \
+  dejagnu \
+  docbook-xsl-stylesheets \
+  doxygen \
+  flex \
+  gcc-c++ \
+  libtool \
+  libxslt \
+  obs-service-source_validator \
+  ruby-devel \
+  sgml-skel \
+  yast2-devtools \
+  yast2-core-devel \
+  yast2-devtools \
+  hwinfo-devel \
+  yast2-ycp-ui-bindings-devel \
+  && zypper clean -a
+COPY yast-travis-cpp /usr/local/bin/
+ENV LC_ALL=en_US.UTF-8
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# run some smoke tests to make sure there is no serious issue with the image
+RUN /usr/lib/YaST2/bin/y2base --help && c++ --version && rake -r yast/rake -V


### PR DESCRIPTION
This is similar to https://github.com/yast/docker-yast-ruby/pull/10:

- Added `Dockerfile.sle12-sp3` file (basically a copy of the `.sle12-sp2` file)
- Use TW as the base system for now (42.3 is not available yet)