### PR TITLE
Workaround: Make Ruby 2.4 the default

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -58,5 +58,8 @@ ENV LC_ALL=en_US.UTF-8
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
+# FIXME: temporary workaround to make Ruby 2.4 default
+RUN cp -a /usr/bin/ruby.ruby2.4 /usr/bin/ruby
+
 # run some smoke tests to make sure there is no serious issue with the image
 RUN /usr/lib/YaST2/bin/y2base --help && c++ --version && rake -r yast/rake -V


### PR DESCRIPTION
Same as in https://github.com/yast/docker-yast-ruby/pull/12