### PR TITLE
Install ruby2.4-devel instead of generic ruby-devel

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -45,7 +45,7 @@ RUN RUBY_VERSION=ruby:2.4.0 && \
   libtool \
   libxslt \
   obs-service-source_validator \
-  ruby-devel \
+  ruby2.4-devel \
   sgml-skel \
   yast2-devtools \
   yast2-core-devel \


### PR DESCRIPTION
Package `ruby2.4-devel` was missining (`ruby-devel` installs `ruby2.2-devel` so there was a 2.2/2.4 mixture again...). 

This is just a port from https://github.com/yast/docker-storage-ng/pull/10, it fixed libstorage-ng build.