### PR TITLE
Explicitly add the "build" package

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -42,6 +42,7 @@ RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
   gcc-c++ \
   libtool \
   libxslt \
+  build \
   obs-service-source_validator \
   ruby-devel \
   sgml-skel \


### PR DESCRIPTION
It should be required by "obs-service-source_validator",
but for some reason the dependency is missing.