### PR TITLE
Revert "Use utils/make_package if present"

### DIFF
--- a/yast-travis-cpp
+++ b/yast-travis-cpp
@@ -10,9 +10,7 @@ set -e -x
 # "osc build" is too resource hungry (builds a complete chroot from scratch).
 # Moreover it does not work in a Docker container (it fails when trying to mount
 # /proc and /sys in the chroot).
-if [ -f utils/make_package ]; then
-  utils/make_package
-elif [ -f Makefile.repo ]; then
+if [ -f Makefile.repo ]; then
   make -f Makefile.repo
   make package
 elif [ -f Rakefile ]; then


### PR DESCRIPTION
Reverts yast/docker-yast-cpp#11

Unfortunately `make_package` cannot handle detached Git Head in Travis :worried:

```
+ VERSION=3.3.18
+ PACKAGE_PREFIX=libstorage-ng-3.3.18
++ '[' -d .git ']'
++ git branch
++ perl -ne 'print $_ if s/^\*\s*//'
+ BRANCH='(HEAD detached at a69684f)'
+ mkdir -p package
+ rm -f 'package/*.tar.xz' 'package/*.changes'
+ git2log --changelog --format obs package/libstorage-ng.changes
+ '[' '!' -d .git ']'
+ git archive --prefix=libstorage-ng-3.3.18/ '(HEAD' detached at 'a69684f)'
fatal: Not a valid object name
```

So let's go back to the `Makefile.repo` way and generate the `.changes` file in libstorage-ng using `git2log` there...