### PR TITLE
Improved security

### DIFF
--- a/Dockerfile.caasp-1_0
+++ b/Dockerfile.caasp-1_0
@@ -3,22 +3,25 @@
 # (which is used as the base for CaaSP) for running the YaST tests.
 FROM opensuse:42.2
 
+# we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
+# and curl for downloading/installing the GPG key
+# see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
+# https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache
+# why we need "zypper clean -a" at the end
+RUN zypper --non-interactive in --no-recommends curl ruby && zypper clean -a
+
+# import the YaST OBS GPG key
+RUN rpm --import https://build.opensuse.org/projects/YaST/public_key
+
 # Set a higher priority for the yast_sle_12_sp2 repo to prefer the packages from
 # this repo even if they have a lower version than the original 42.2 packages.
-RUN zypper ar -f -p95 http://download.opensuse.org/repositories/YaST:/SLE-12:/SP2/SLE_12_SP2/ \
+RUN zypper ar -f -p95 https://download.opensuse.org/repositories/YaST:/SLE-12:/SP2/SLE_12_SP2/ \
   yast_sle_12_sp2
 
 # Set the highest priority for the yast_caasp_1.0 repo to override the
 # yast_sle_12_sp2 and the original 42.2 packages.
-RUN zypper ar -f -p30 http://download.opensuse.org/repositories/YaST:/CASP:/1.0/SLE_12_SP2/ \
+RUN zypper ar -f -p30 https://download.opensuse.org/repositories/YaST:/CASP:/1.0/SLE_12_SP2/ \
   yast_caasp_1.0
-
-# we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
-# see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
-# https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache
-# why we need "zypper clean -a" at the end
-RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-  ruby && zypper clean -a
 
 RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
   zypper --gpg-auto-import-keys --non-interactive in --no-recommends \

--- a/Dockerfile.caasp-1_0
+++ b/Dockerfile.caasp-1_0
@@ -24,7 +24,7 @@ RUN zypper ar -f -p30 https://download.opensuse.org/repositories/YaST:/CASP:/1.0
   yast_caasp_1.0
 
 RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
-  zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+  zypper --non-interactive in --no-recommends \
   aspell-en \
   fdupes \
   git \

--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -1,16 +1,19 @@
 FROM opensuse:tumbleweed
-RUN zypper ar -f http://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed/ yast
 
-# "zypper dup" synchronizes with the current Tumbleweed (even downgrades if needed)
-RUN zypper --gpg-auto-import-keys --non-interactive dup --no-recommends \
-  && zypper clean -a
-
+# "zypper dup" synchronizes with the current Tumbleweed (even downgrades if needed),
 # we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
+# and curl for downloading/installing the GPG key
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
 # https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache
 # why we need "zypper clean -a" at the end
-RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-  ruby && zypper clean -a
+RUN zypper --non-interactive dup --no-recommends && \
+  zypper --non-interactive in --no-recommends curl ruby && \
+  zypper clean -a
+
+# import the YaST OBS GPG key
+RUN rpm --import https://build.opensuse.org/projects/YaST/public_key
+
+RUN zypper ar -f https://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed/ yast
 
 RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
   zypper --gpg-auto-import-keys --non-interactive in --no-recommends \

--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -16,7 +16,7 @@ RUN rpm --import https://build.opensuse.org/projects/YaST/public_key
 RUN zypper ar -f https://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed/ yast
 
 RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
-  zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+  zypper --non-interactive in --no-recommends \
   aspell-en \
   fdupes \
   git \

--- a/Dockerfile.sle12-sp2
+++ b/Dockerfile.sle12-sp2
@@ -20,7 +20,7 @@ RUN zypper ar -f -p 95 https://download.opensuse.org/repositories/YaST:/SLE-12:/
   yast_sle12_sp2
 
 RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
-  zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+  zypper --non-interactive in --no-recommends \
   aspell-en \
   fdupes \
   git \

--- a/Dockerfile.sle12-sp2
+++ b/Dockerfile.sle12-sp2
@@ -4,17 +4,20 @@
 # for running the YaST tests.
 FROM opensuse:42.2
 
-# Set a higher priority for the yast_sle_12_sp2 repo to prefer the packages from
-# this repo even if they have a lower version than the original 42.2 packages.
-RUN zypper ar -f -p 95 http://download.opensuse.org/repositories/YaST:/SLE-12:/SP2/SLE_12_SP2/ \
-  yast_sle12_sp2
-
 # we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
+# and curl for downloading/installing the GPG key
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
 # https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache
 # why we need "zypper clean -a" at the end
-RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-  ruby && zypper clean -a
+RUN zypper --non-interactive in --no-recommends curl ruby && zypper clean -a
+
+# import the YaST OBS GPG key
+RUN rpm --import https://build.opensuse.org/projects/YaST/public_key
+
+# Set a higher priority for the yast_sle_12_sp2 repo to prefer the packages from
+# this repo even if they have a lower version than the original 42.2 packages.
+RUN zypper ar -f -p 95 https://download.opensuse.org/repositories/YaST:/SLE-12:/SP2/SLE_12_SP2/ \
+  yast_sle12_sp2
 
 RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
   zypper --gpg-auto-import-keys --non-interactive in --no-recommends \

--- a/Dockerfile.sle12-sp3
+++ b/Dockerfile.sle12-sp3
@@ -20,7 +20,7 @@ RUN zypper ar -f -p 95 https://download.opensuse.org/repositories/YaST:/SLE-12:/
   yast_sle12_sp3
 
 RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
-  zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+  zypper --non-interactive in --no-recommends \
   aspell-en \
   fdupes \
   git \

--- a/Dockerfile.sle12-sp3
+++ b/Dockerfile.sle12-sp3
@@ -2,22 +2,22 @@
 # because of some licensing issues, use openSUSE-42.3 as a replacement.
 # It shares the same core packages and should be close enough to SLE12-SP3
 # for running the YaST tests.
-# FIXME: for now use our own 42.3 image, the officiall image has not been
-# published yet
-# TODO: FROM opensuse:42.3
-FROM yastdevel/opensuse-42.3
-
-# Set a higher priority for the yast_sle_12_sp3 repo to prefer the packages from
-# this repo even if they have a lower version than the original 42.3 packages.
-RUN zypper ar -f -p 95 http://download.opensuse.org/repositories/YaST:/SLE-12:/SP3/openSUSE_Leap_42.3/ \
-  yast_sle12_sp3
+FROM opensuse:42.3
 
 # we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
+# and curl for downloading/installing the GPG key
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
 # https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache
 # why we need "zypper clean -a" at the end
-RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-  ruby && zypper clean -a
+RUN zypper --non-interactive in --no-recommends curl ruby && zypper clean -a
+
+# import the YaST OBS GPG key
+RUN rpm --import https://build.opensuse.org/projects/YaST/public_key
+
+# Set a higher priority for the yast_sle_12_sp3 repo to prefer the packages from
+# this repo even if they have a lower version than the original 42.3 packages.
+RUN zypper ar -f -p 95 https://download.opensuse.org/repositories/YaST:/SLE-12:/SP3/openSUSE_Leap_42.3/ \
+  yast_sle12_sp3
 
 RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
   zypper --gpg-auto-import-keys --non-interactive in --no-recommends \


### PR DESCRIPTION
This is the same as https://github.com/yast/docker-yast-ruby/pull/17

- Do not automatically import any "random" GPG key (via `--gpg-auto-import-keys`
  zypper option),  instead import the specific YaST GPG key downloaded from OBS
- Use HTTPS for the repository URLs (instead of plain HTTP)
- Switched to the official openSUSE-42.3 image