### PR TITLE
Fixed evaluating the ruby version

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -15,7 +15,7 @@ RUN rpm --import https://build.opensuse.org/projects/YaST/public_key
 
 RUN zypper ar -f https://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed/ yast
 
-RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
+RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   zypper --non-interactive in --no-recommends \
   aspell-en \
   fdupes \


### PR DESCRIPTION
- Fixes the Docker build
- The `rb_default_ruby_abi` RPM is not defined anymore, we have to use `rb_ver` instead.