### PR TITLE
Install coveralls

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -25,6 +25,7 @@ RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   update-desktop-files \
   which \
   screen \
+  "rubygem($RUBY_VERSION:coveralls)" \
   "rubygem($RUBY_VERSION:fast_gettext)" \
   "rubygem($RUBY_VERSION:gettext)" \
   "rubygem($RUBY_VERSION:raspell)" \


### PR DESCRIPTION
this image already installs simplecov (0.15) and it is hard to install
coveralls in a subsequent image, because it requires a slightly
different version (vendor change and/or downgrade)

I want this for yast2-users (which is a hybrid cpp+ruby package)