### PR TITLE
Added BRP packages to be more compatible with "osc build"

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -21,6 +21,8 @@ RUN zypper ar -f https://download.opensuse.org/repositories/YaST:/Head/openSUSE_
 RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   zypper --non-interactive in --no-recommends \
   aspell-en \
+  brp-check-suse \
+  brp-extract-appdata \
   fdupes \
   git \
   grep \


### PR DESCRIPTION
This is similar to https://github.com/yast/docker-yast-ruby/pull/31, check it for more details.
