### PR TITLE
Added shellcheck, run syntax check for all found Perl files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ services:
   - docker
 
 script:
-  # at least run a syntax check for the Travis script
-  - bash -n yast-travis-cpp
   # build the Docker image
   - docker build -t yast-test-image -f Dockerfile.$DOCKER_TAG .
+  # check the Travis script
+  - 'if [ "$DOCKER_TAG" = "latest" ]; then docker run -it yast-test-image shellcheck /usr/local/bin/yast-travis-cpp; fi'
 
 env:
   # define the build matrix to build all images in parallel

--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -55,6 +55,7 @@ RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   obs-service-source_validator \
   ruby-devel \
   sgml-skel \
+  ShellCheck \
   yast2-devtools \
   yast2-core-devel \
   yast2-devtools \

--- a/yast-travis-cpp
+++ b/yast-travis-cpp
@@ -6,6 +6,15 @@
 # exit on error immediately, print the executed commands
 set -e -x
 
+# run perl syntax check when there is at least one Perl file
+if [ -n "$(find . -name '*.p[ml]' -print -quit)" ]; then
+  echo "Checking Perl files..."
+  # Perl allows checking the syntax only for one file at once, we need to use -n1
+  # xargs option, to speed it up run the checks in parallel (-P option).
+  # If you need to specify an additional search path use the PERL5LIB environment variable.
+  find . -name '*.p[ml]' -print0 | xargs -0 -P"$(nproc)" -n1 perl -I src/modules -I /usr/share/YaST2/modules -w -c
+fi
+
 # Build the binary package locally, use plain "rpmbuild" to make it simple.
 # "osc build" is too resource hungry (builds a complete chroot from scratch).
 # Moreover it does not work in a Docker container (it fails when trying to mount
@@ -39,4 +48,5 @@ rpmbuild -bb package/*.spec || rpmbuild -bb --nodeps package/*.spec
 rpm -iv --force --nodeps /usr/src/packages/RPMS/**/*.rpm
 rpm -Uv --force --nodeps /usr/src/packages/RPMS/**/*.rpm
 # get the plain package names and remove all packages at once
-rpm -ev --nodeps `rpm -q --qf '%{NAME} ' -p /usr/src/packages/RPMS/**/*.rpm`
+mapfile -t packages < <(rpm -q --qf '%{NAME}\n' -p /usr/src/packages/RPMS/*/*.rpm)
+rpm -ev --nodeps "${packages[@]}"


### PR DESCRIPTION
- Added shellcheck package, it can be used in Travis also by the other packages
- Use it for checking the Travis script, adapted the script to pass (the same code is in the [yast-travis-ruby](https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby) script)
- Run syntax check for all found Perl files
  - Currently there is no way how to disable that, hopefully we will not need that :wink: 